### PR TITLE
2nd order immersed boundary for Vlasov solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ reports/
 .cache/
 .ipynb_checkpoints
 *.png
+*.svg
 *.mp4
 .DS_Store
 .devcontainer/*

--- a/examples/cylinder/main.cpp
+++ b/examples/cylinder/main.cpp
@@ -55,8 +55,9 @@ struct ImmersedWorld : World<ImmersedWorld> {
 
         Kokkos::parallel_for(
             Kokkos::MDRangePolicy({0, 0}, {nx, ny}), KOKKOS_CLASS_LAMBDA(const int i, const int j) {
-                // potential and electric field are continuous
+                // potential is continuous
                 a(i, j) = 0.0;
+                // electric field is not continuous but this works??
                 b(i, j) = 0.0;
 
                 // the immersed cylinder is a conductor, set a high permittivity
@@ -73,7 +74,7 @@ struct ImmersedWorld : World<ImmersedWorld> {
         int ny       = u.extent(1);
         double dx    = grid.size[0] / (nx - 2 * ngc);
         double dy    = grid.size[1] / (ny - 2 * ngc);
-        double phi_w = -66.67; // normalized potential at the wall of the charged cylinder
+        double phi_w = -20.0 / (2 * 0.15); // cylinder potential normalized to electron quantities
         Kokkos::parallel_for(
             Kokkos::MDRangePolicy({ngc, ngc}, {nx - ngc, ny - ngc}), KOKKOS_CLASS_LAMBDA(const int i, const int j) {
                 double x   = (i - ngc + 0.5) * dx;

--- a/examples/cylinder/plottings.py
+++ b/examples/cylinder/plottings.py
@@ -20,9 +20,6 @@ plt.rcParams.update(
 nx, ny = 160, 50
 Lx, Ly = 1, 0.5
 G = 3
-Ti = 1  # eV
-Te = 1  # eV
-Tr = Ti / Te
 is_include_circle = True
 
 step = 300

--- a/examples/cylinder/plottings.py
+++ b/examples/cylinder/plottings.py
@@ -20,6 +20,11 @@ plt.rcParams.update(
 nx, ny = 160, 50
 Lx, Ly = 1, 0.5
 G = 3
+Ti = 1  # eV
+Te = 1  # eV
+Tr = Ti / Te
+is_include_circle = True
+
 step = 300
 file_path = os.path.dirname(os.path.realpath(__file__))
 with h5py.File(
@@ -30,87 +35,92 @@ with h5py.File(
     Ex = f["VTKHDF/CellData/Ex"][:].reshape(nx + 2 * G, ny + 2 * G)
     phi = f["VTKHDF/CellData/phi"][:].reshape(nx + 2 * G, ny + 2 * G)
 
-ni = ni[G:-G, G:-G]
-Ex = Ex[G:-G, G:-G]
-phi = phi[G:-G, G:-G]
-
 dx = Lx / nx
 dy = Ly / ny
-x = np.arange(dx / 2, Lx, dx)
-y = np.arange(dy / 2, Ly, dy)
-Y, X = np.meshgrid(y, x)
+x = np.arange(dx / 2 - G * dx, Lx + G * dx, dx)
+y = np.arange(dy / 2 - G * dy, Ly + G * dy, dy)
+X, Y = np.meshgrid(x, y, indexing="ij")
 
 fig, ax = plt.subplots(figsize=(6, 3))
 c = ax.contourf(X, Y, ni, cmap="jet", levels=50)
-plt.colorbar(c, label="$n_i$")
-circle = Wedge(
-    center=(0.375, 0),
-    r=0.125,
-    theta1=0,
-    theta2=180,
-    facecolor="white",
-    edgecolor="k",
-    linewidth=2,
-)
-ax.add_patch(circle)
-ax.set_xlim(dx / 2, Lx - dx / 2)
-ax.set_ylim(dy / 2, Ly - dy / 2)
-ax.set_xlabel("$x$")
-ax.set_ylabel("$y$")
-plt.savefig(f"{file_path}/number_density.png")
+plt.colorbar(c)
+plt.title("$n_i$")
+if is_include_circle:
+    circle = Wedge(
+        center=(0.375, 0),
+        r=0.125,
+        theta1=0,
+        theta2=180,
+        facecolor="white",
+        edgecolor="k",
+        linewidth=2,
+    )
+    ax.add_patch(circle)
+ax.set_xlim(0, 1)
+ax.set_ylim(0, 0.5)
+ax.set_xlabel("$x/L_x$")
+ax.set_ylabel("$y/L_x$")
+plt.tight_layout()
+plt.savefig(f"{file_path}/number_density.svg")
 
 fig, ax = plt.subplots(figsize=(6, 3))
 c = ax.contourf(X, Y, phi, cmap="jet", levels=50)
-plt.colorbar(c, label="$\\phi$")
-circle = Wedge(
-    center=(0.375, 0),
-    r=0.125,
-    theta1=0,
-    theta2=180,
-    facecolor="white",
-    edgecolor="k",
-    linewidth=2,
-)
-ax.add_patch(circle)
-ax.set_xlim(dx / 2, Lx - dx / 2)
-ax.set_ylim(dy / 2, Ly - dy / 2)
-ax.set_xlabel("$x$")
-ax.set_ylabel("$y$")
-plt.savefig(f"{file_path}/potential.png")
+plt.colorbar(c)
+plt.title("$e\\phi/2k_BT_i$")
+if is_include_circle:
+    circle = Wedge(
+        center=(0.375, 0),
+        r=0.125,
+        theta1=0,
+        theta2=180,
+        facecolor="white",
+        edgecolor="k",
+        linewidth=2,
+    )
+    ax.add_patch(circle)
+ax.set_xlim(0, 1)
+ax.set_ylim(0, 0.5)
+ax.set_xlabel("$x/L_x$")
+ax.set_ylabel("$y/L_x$")
+plt.tight_layout()
+plt.savefig(f"{file_path}/potential.svg")
 
 fig, ax = plt.subplots(figsize=(6, 3))
 c = ax.contourf(X, Y, Ex, cmap="jet", levels=50)
-plt.colorbar(c, label="$E_x$")
-circle = Wedge(
-    center=(0.375, 0),
-    r=0.125,
-    theta1=0,
-    theta2=180,
-    facecolor="white",
-    edgecolor="k",
-    linewidth=2,
-)
-ax.add_patch(circle)
+plt.colorbar(c)
+plt.title("$eE_x/m_ev_{th,e}\\omega_{pe}$")
+if is_include_circle:
+    circle = Wedge(
+        center=(0.375, 0),
+        r=0.125,
+        theta1=0,
+        theta2=180,
+        facecolor="white",
+        edgecolor="k",
+        linewidth=2,
+    )
+    ax.add_patch(circle)
 ax.set_xlim(dx / 2, Lx - dx / 2)
 ax.set_ylim(dy / 2, Ly - dy / 2)
-ax.set_xlabel("$x$")
-ax.set_ylabel("$y$")
-plt.savefig(f"{file_path}/electric_field.png")
+ax.set_xlabel("$x/L_x$")
+ax.set_ylabel("$y/L_x$")
+plt.tight_layout()
+plt.savefig(f"{file_path}/electric_field.svg")
 
 plt.figure()
 plt.plot(x, Ex[:, G], "o-", label="$y=0$")
 plt.plot(x, Ex[:, -G], "o-", label="$y=0.5$")
-plt.xlabel("$x$")
+plt.xlabel("$x/L_x$")
 plt.ylabel("$E_x$")
 plt.legend()
-plt.savefig(f"{file_path}/electric_field_profiles.png")
+plt.savefig(f"{file_path}/electric_field_profiles.svg")
 
 plt.figure()
 plt.plot(x, phi[:, G], "o-", label="$y=0$")
 plt.plot(x, phi[:, -G], "o-", label="$y=0.5$")
-plt.xlabel("$x$")
+plt.xlabel("$x/L_x$")
 plt.ylabel("$\\phi$")
 plt.legend()
-plt.savefig(f"{file_path}/potential_profiles.png")
+plt.savefig(f"{file_path}/potential_profiles.svg")
 
 plt.show()

--- a/include/reduced/grid.hpp
+++ b/include/reduced/grid.hpp
@@ -48,7 +48,7 @@ struct Grid {
     }
 
     /**
-     * Calculate the center of the cell given its coordinate indexes of cells (including ghost cells).
+     * Calculate the center of the cell given its coordinate indexes (including ghost cells).
      *
      * @param coord_idx Coordinate indexes of the cell, starts from 0 to ncells - 1.
      * @return A Kokkos::Array containing the center coordinates in the x and v directions.
@@ -61,6 +61,30 @@ struct Grid {
             origin[1] + (coord_idx[1] - ngc) * dy + dy / 2.0,   // center in the y-direction
             origin[2] + (coord_idx[2] - ngc) * dvx + dvx / 2.0, // center in the vx-direction
             origin[3] + (coord_idx[3] - ngc) * dvy + dvy / 2.0  // center in the vy-direction
+        };
+    };
+
+    /**
+     * Calculate the logical coordinate of the cell given its position (including ghost cells).
+     *
+     * @param center Position of the cell
+     * @return A Kokkos::Array containing the logical coordinates in the x and v directions.
+     **/
+    KOKKOS_INLINE_FUNCTION
+    Kokkos::Array<int, DIM> coord(const Kokkos::Array<double, DIM> center) const {
+        auto [dx, dy, dvx, dvy] = spacing;
+        // don't use {} initialization to avoid narrowing conversion warning
+        // Kokkos::Array<int, DIM> coord_idx;
+        // coord_idx[0] = static_cast<int>((center[0] - origin[0] - dx / 2.0) / dx) + ngc;   // coord in the x-direction
+        // coord_idx[1] = static_cast<int>((center[1] - origin[1] - dy / 2.0) / dy) + ngc;   // coord in the y-direction
+        // coord_idx[2] = static_cast<int>((center[2] - origin[2] - dvx / 2.0) / dvx) + ngc; // coord in the
+        // vx-direction coord_idx[3] = static_cast<int>((center[3] - origin[3] - dvy / 2.0) / dvy) + ngc; // coord in
+        // the vy-direction return coord_idx;
+        return {
+            static_cast<int>((center[0] - origin[0] - dx / 2.0) / dx) + ngc,   // coord in the x-direction
+            static_cast<int>((center[1] - origin[1] - dy / 2.0) / dy) + ngc,   // coord in the y-direction
+            static_cast<int>((center[2] - origin[2] - dvx / 2.0) / dvx) + ngc, // coord in the vx-direction
+            static_cast<int>((center[3] - origin[3] - dvy / 2.0) / dvy) + ngc, // coord in the vy-direction
         };
     };
 };

--- a/include/reduced/vlasov.hpp
+++ b/include/reduced/vlasov.hpp
@@ -32,33 +32,7 @@ class Vlasolver {
           poisson_solver(poisson_solver),
           writer(writer) {}
 
-    // void initialize_distribution() const {
-    //     using Kokkos::cos;
-    //     using Kokkos::exp;
-    //     using Kokkos::pow;
-    //     using Kokkos::sqrt;
-    //     using Kokkos::numbers::pi;
-    //
-    //     // must assign grid and f here, otherwise, using world.grid.xxx in device region causes illegal memory access
-    //     auto& grid              = world.grid;
-    //     auto& f                 = world.f;
-    //
-    //     auto [nx, ny, nvx, nvy] = grid.ncells;
-    //     auto [dx, dy, dvx, dvy] = grid.spacing;
-    //     auto [Lx, Ly, Lvx, Lvy] = grid.size;
-    //     int ngc                 = grid.ngc;
-    //
-    //     Kokkos::parallel_for(
-    //         Kokkos::MDRangePolicy({0, 0, 0, 0}, {nx, ny, nvx, nvy}),
-    //         KOKKOS_CLASS_LAMBDA(const int i, const int j, const int iv, const int jv) {
-    //             if (iv < ngc || iv >= nvx - ngc || jv < ngc || jv >= nvy - ngc)
-    //                 return;
-    //
-    //             f(i, j, iv, jv) = 0.0;
-    //         });
-    // }
-
-    void extrapolate_distribution_function() const {
+    void extrapolate_distribution_1st_order() const {
         auto& grid              = world.grid;
         auto& f                 = world.f;
         auto [nx, ny, nvx, nvy] = grid.ncells;
@@ -119,8 +93,119 @@ class Vlasolver {
                 }
 
                 if (Ng > 0)
-                    // f(i, j, iv, jv) = extrapolated_value / Ng;
+                    // f(i, j, iv, jv) = extrapolated_value / Ng; // this doesn't work
                     f(i, j, iv, jv) = Kokkos::max(0.0, extrapolated_value / Ng);
+            });
+    }
+
+    void extrapolate_distribution_2nd_order() const {
+        using Kokkos::abs;
+        using Kokkos::sqrt;
+        auto& grid              = world.grid;
+        auto& f                 = world.f;
+        auto [nx, ny, nvx, nvy] = grid.ncells;
+        int ngc                 = grid.ngc;
+        double dx               = grid.spacing[0];
+        double dy               = grid.spacing[1];
+
+        // first point must be further enough so interpolation won't involve ghost cell
+        double s = sqrt(dx * dx + dy * dy); // cell diagonal length
+
+        Kokkos::parallel_for(
+            Kokkos::MDRangePolicy({ngc, ngc, ngc, ngc}, {nx - ngc, ny - ngc, nvx - ngc, nvy - ngc}),
+            KOKKOS_CLASS_LAMBDA(const int i, const int j, const int iv, const int jv) {
+                auto [x, y, vx, vy] = grid.center({i, j, iv, jv});
+
+                // always extrapolate dist function from the interior of the immersed object
+                double eta = world.surface(x, y);
+                if (eta >= 0.0)
+                    return;
+
+                // now (x,y) is the interior of the immersed object
+                double eta_l   = world.surface(x - dx, y);
+                double eta_r   = world.surface(x + dx, y);
+                double eta_b   = world.surface(x, y - dy);
+                double eta_t   = world.surface(x, y + dy);
+                auto [n1, n2]  = world.normal(x, y, dx, dy);
+                double v_dot_n = vx * n1 + vy * n2;
+                // extrapolate outflow (v.n < 0), zero-inflow(v.n >= 0)
+                if (eta * eta_l < 0.0 || eta * eta_r < 0.0 || eta * eta_b < 0.0 || eta * eta_t < 0.0) {
+
+                    // best fit line
+                    const size_t N = 4;
+                    Kokkos::Array<double, N> s_vals;
+                    Kokkos::Array<double, N> f_vals;
+                    for (int k = 0; k < N; ++k) {
+                        s_vals[k]                 = (k + 1) * s;
+                        double x_k                = x + s_vals[k] * n1;
+                        double y_k                = y + s_vals[k] * n2;
+                        auto [ic, jc, ivxc, ivyc] = grid.coord({x_k, y_k, vx, vy});
+                        auto [xc, yc, vxc, vyc]   = grid.center({ic, jc, ivxc, ivyc});
+                        f_vals[k] = f(ic, jc, iv, jv) * (1.0 - (x_k - xc) / dx) * (1.0 - (y_k - yc) / dy) +
+                                    f(ic + 1, jc, iv, jv) * ((x_k - xc) / dx) * (1.0 - (y_k - yc) / dy) +
+                                    f(ic, jc + 1, iv, jv) * (1.0 - (x_k - xc) / dx) * ((y_k - yc) / dy) +
+                                    f(ic + 1, jc + 1, iv, jv) * ((x_k - xc) / dx) * ((y_k - yc) / dy);
+                    }
+                    // for inflow case, we take the zero-inflow condition into account
+                    double c0 = 0.0, c1 = 0.0;
+                    if (v_dot_n >= 0.0) {
+                        s_vals[N - 1] = abs(eta);
+                        f_vals[N - 1] = 0.0;
+                        double bot = 0.0, top = 0.0;
+                        for (int k = 0; k < N; ++k) {
+                            top += s_vals[k] * f_vals[k];
+                            bot += s_vals[k] * s_vals[k];
+                        }
+                        c1 = top / bot;
+                        c0 = 0.0;
+                    } else {
+                        double f_mean = 0.0, s_mean = 0.0, bot = 0.0, top = 0.0;
+                        for (int k = 0; k < N; ++k) {
+                            if (s_mean == 0.0) {
+                                for (int m = 0; m < N; ++m) {
+                                    s_mean += s_vals[k] / N;
+                                    f_mean += f_vals[k] / N;
+                                }
+                            }
+
+                            top += (s_vals[k] - s_mean) * (f_vals[k] - f_mean);
+                            bot += (s_vals[k] - s_mean) * (s_vals[k] - s_mean);
+                        }
+
+                        c1 = top / bot;
+                        c0 = f_mean - c1 * s_mean;
+                    }
+
+                    f(i, j, iv, jv) = c0 + c1 * eta; // eta is negative
+
+                    // double f_F1 = 0.0, f_F2 = 0.0;
+                    // {
+                    //     double x1                 = x + s1 * n1;
+                    //     double y1                 = y + s1 * n2;
+                    //     auto [ic, jc, ivxc, ivyc] = grid.coord({x1, y1, vx, vy});
+                    //     auto [xc, yc, vxc, vyc]   = grid.center({ic, jc, ivxc, ivyc});
+                    //     f_F1 = f(ic, jc, iv, jv) * (1.0 - (x1 - xc) / dx) * (1.0 - (y1 - yc) / dy) +
+                    //            f(ic + 1, jc, iv, jv) * ((x1 - xc) / dx) * (1.0 - (y1 - yc) / dy) +
+                    //            f(ic, jc + 1, iv, jv) * (1.0 - (x1 - xc) / dx) * ((y1 - yc) / dy) +
+                    //            f(ic + 1, jc + 1, iv, jv) * ((x1 - xc) / dx) * ((y1 - yc) / dy);
+                    // };
+                    // {
+                    //     double x2                 = x + s2 * n1;
+                    //     double y2                 = y + s2 * n2;
+                    //     auto [ic, jc, ivxc, ivyc] = grid.coord({x2, y2, vx, vy});
+                    //     auto [xc, yc, vxc, vyc]   = grid.center({ic, jc, ivxc, ivyc});
+                    //     f_F2 = f(ic, jc, iv, jv) * (1.0 - (x2 - xc) / dx) * (1.0 - (y2 - yc) / dy) +
+                    //            f(ic + 1, jc, iv, jv) * ((x2 - xc) / dx) * (1.0 - (y2 - yc) / dy) +
+                    //            f(ic, jc + 1, iv, jv) * (1.0 - (x2 - xc) / dx) * ((y2 - yc) / dy) +
+                    //            f(ic + 1, jc + 1, iv, jv) * ((x2 - xc) / dx) * ((y2 - yc) / dy);
+                    // };
+                    //
+                    // double f_I =
+                    //     (v_dot_n < 0.0) ? (s2 - abs(eta)) / (s2 - s1) * f_F1 + (abs(eta) - s1) / (s2 - s1) * f_F2 :
+                    //     0.0;
+                    // f(i, j, iv, jv) = s1 / (s1 - abs(eta)) * f_I - abs(eta) / (s1 - abs(eta)) * f_F1;
+                    f(i, j, iv, jv) = Kokkos::max(f(i, j, iv, jv), 0.0);
+                }
             });
     }
 
@@ -520,7 +605,8 @@ class Vlasolver {
         pfc_update(dt / 2.0, 1);
         Kokkos::printf("(VlasovSolver) Solving electric field\n");
         world.particle_boundary_conditions();
-        extrapolate_distribution_function();
+        // extrapolate_distribution_1st_order();
+        extrapolate_distribution_2nd_order();
         compute_charge_density();
         world.poisson_jump_conditions();
         poisson_solver.solve();
@@ -530,19 +616,22 @@ class Vlasolver {
         // Kokkos::printf("(VlasovSolver) PFC update along velocity by dt, vy\n");
         pfc_update(dt, 3);
         world.particle_boundary_conditions();
-        extrapolate_distribution_function();
+        // extrapolate_distribution_1st_order();
+        extrapolate_distribution_2nd_order();
         Kokkos::printf("(VlasovSolver) PFC update along space by dt/2\n");
         pfc_update(dt / 2.0, 0);
         pfc_update(dt / 2.0, 1);
         world.particle_boundary_conditions();
-        extrapolate_distribution_function();
+        // extrapolate_distribution_1st_order();
+        extrapolate_distribution_2nd_order();
     }
 
     void solve() {
         Kokkos::printf("Step %zu:\n", 0);
         world.initialize_distribution();
         world.particle_boundary_conditions();
-        extrapolate_distribution_function();
+        // extrapolate_distribution_1st_order();
+        extrapolate_distribution_2nd_order();
         compute_charge_density();
         world.poisson_jump_conditions();
         poisson_solver.solve();


### PR DESCRIPTION
Currently the ghost cell value in Vlasov solver is extrapolated by a best-fit line using data points along the normal of the immersed boundary. Later on we can upgrade this to extrapolate the ghost cell value using all data points within a circle of certain radius of the ghost value. I guess this will be more robust.

However, we need to upgrade the Poisson solver so that the electric field has 2nd order accuracy because the entire solver achieves 2nd order accuracy.
